### PR TITLE
Use the home directory and other user info from /etc/passwd

### DIFF
--- a/libnss_ato.c
+++ b/libnss_ato.c
@@ -44,6 +44,7 @@ read_conf()
 {
 	FILE *fd;
 	struct passwd *conf;
+	struct passwd *conf2;
 
 	if ((fd = fopen(CONF_FILE, "r")) == NULL ) {
 		return NULL;
@@ -57,7 +58,14 @@ read_conf()
 		conf->pw_gid = MIN_GID_NUMBER;
 
 	fclose(fd);
-	return conf;
+
+	/* Now we've got the UID to match to, get the full entry from
+	 * /etc/passwd. This means we don't need to specify the right home directory in
+	 * our conf file. */
+
+	conf2 = getpwuid(conf->pw_uid);
+
+	return conf2;
 }
 
 /* 


### PR DESCRIPTION
When using libnss-ato, we found that we were having to duplictate data - things like the username and home directory had to be specified in both libnss-ato.conf and in /etc/passwd.

This PR tweaks this to pull that data out of /etc/passwd, just using /etc/libnss-ato.conf for the UID of the all-in-one user.

I haven't made this configurable - are there use-cases where someone would want different data for a user than is in /etc/passwd?