### PR TITLE
Basic CI support via travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: c
+sudo: false
+
+script:
+  - make
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,11 @@ sudo: false
 script:
   - make
 
+matrix:
+  include:
+  - os: linux
+    compiler: gcc
+  - os: linux
+    compiler: clang
+
 

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ manprefix =
 all:	libnss_ato libnss_ato_test 
 
 libnss_ato:	libnss_ato.c
-	${CC} -fPIC -Wall -shared -o libnss_ato.so.2 -Wl,-soname,libnss_ato.so.2 libnss_ato.c
+	${CC} ${CFLAGS} ${LDFLAGS} -fPIC -Wall -shared -o libnss_ato.so.2 -Wl,-soname,libnss_ato.so.2 libnss_ato.c
 
 test:	libnss_ato_test.c
-	${CC} -fPIC -Wall -o libnss_ato_test libnss_ato_test.c
+	${CC} ${CFLAGS} ${LDFLAGS} -fPIC -Wall -o libnss_ato_test libnss_ato_test.c
 
 install:	
 	# remeber  /lib/libnss_compat.so.2 -> libnss_compat-2.3.6.so

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/donapieppo/libnss-ato.svg?branch=master)](https://travis-ci.org/donapieppo/libnss-ato)
+
 libnss-ato (Name Service Switch module All-To-One)
 ==========
 


### PR DESCRIPTION
This adds basic CI support (compile) via travis.

(You have to turn on for your own repository, and also this could be included for check api.)
In my fork it is green: https://travis-ci.org/Kokan/libnss-ato/branches