### PR TITLE
Fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ manprefix =
 
 #### End of system configuration section. ####
 
-all:	libnss_ato libnss_ato_test 
+all:	libnss_ato libnss_ato_test
 
 libnss_ato:	libnss_ato.c
 	${CC} ${CFLAGS} ${LDFLAGS} -fPIC -Wall -shared -o libnss_ato.so.2 -Wl,-soname,libnss_ato.so.2 libnss_ato.c
@@ -30,7 +30,7 @@ libnss_ato:	libnss_ato.c
 test:	libnss_ato_test.c
 	${CC} ${CFLAGS} ${LDFLAGS} -fPIC -Wall -o libnss_ato_test libnss_ato_test.c
 
-install:	
+install:
 	# remeber  /lib/libnss_compat.so.2 -> libnss_compat-2.3.6.so
 	${INSTALL_DATA} libnss_ato.so.2 ${prefix}/lib/libnss_ato-2.3.6.so
 	${INSTALL_DATA} libnss-ato.3 ${prefix}/usr/share/man/man3

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ CC = gcc
 INSTALL = /usr/bin/install
 INSTALL_PROGRAM = ${INSTALL}
 INSTALL_DATA = ${INSTALL} -m 644
+DESTDIR = ""
 
-prefix = ""
+prefix = "/usr"
 exec_prefix = ${prefix}
 
 # Where the installed binary goes.
@@ -32,9 +33,9 @@ test:	libnss_ato_test.c
 
 install:
 	# remeber  /lib/libnss_compat.so.2 -> libnss_compat-2.3.6.so
-	${INSTALL_DATA} libnss_ato.so.2 ${prefix}/lib/libnss_ato-2.3.6.so
-	${INSTALL_DATA} libnss-ato.3 ${prefix}/usr/share/man/man3
-	cd ${prefix}/lib && ln -fs libnss_ato-2.3.6.so libnss_ato.so.2
+	${INSTALL_DATA} libnss_ato.so.2 ${DESTDIR}/${prefix}/lib/libnss_ato-2.3.6.so
+	${INSTALL_DATA} libnss-ato.3 ${DESTDIR}/${prefix}/share/man/man3
+	cd ${DESTDIR}/${prefix}/lib && ln -fs libnss_ato-2.3.6.so libnss_ato.so.2
 
 clean:
 	rm -f libnss_ato.so.2 libnss_ato_test

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ sysconfdir = /etc
 
 # mandir = /usr/local/src/less-394/debian/less/usr/share/man
 manext = 1
-manprefix =
+manprefix = ${prefix}/share/man
 
 #### End of system configuration section. ####
 
@@ -34,7 +34,7 @@ test:	libnss_ato_test.c
 install:
 	# remeber  /lib/libnss_compat.so.2 -> libnss_compat-2.3.6.so
 	${INSTALL_DATA} libnss_ato.so.2 ${DESTDIR}/${prefix}/lib/libnss_ato-2.3.6.so
-	${INSTALL_DATA} libnss-ato.3 ${DESTDIR}/${prefix}/share/man/man3
+	${INSTALL_DATA} libnss-ato.3 ${DESTDIR}/${manprefix}/man3
 	cd ${DESTDIR}/${prefix}/lib && ln -fs libnss_ato-2.3.6.so libnss_ato.so.2
 
 clean:


### PR DESCRIPTION
Currently, there are few issues in makefile which makes shipping the deliverables uneasy during rpm build.

This patch fixes it.