### PR TITLE
Update rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,7 @@
 export DH_VERBOSE=1
 
 # This is the debhelper compatibility version to use.
-export DH_COMPAT=5
+export DH_COMPAT=10
 
 build: build-stamp
 build-stamp:


### PR DESCRIPTION
Fixing build error:
dh_clean: error: Compatibility levels before 7 are no longer supported (level 5 requested)